### PR TITLE
Transaction service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,9 @@ dependencies {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web:2.6.7'
+
+    implementation 'org.projectlombok:lombok:1.18.22'
+    implementation 'org.springframework.boot:spring-boot-starter-web:2.6.7'
 }
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/java/com/mendel/challenge/service/TransactionService.java
+++ b/src/main/java/com/mendel/challenge/service/TransactionService.java
@@ -2,8 +2,10 @@ package com.mendel.challenge.service;
 
 import com.mendel.challenge.entity.Transaction;
 
+import java.util.List;
+
 public interface TransactionService {
     Transaction get(Long id);
-    Transaction getByType(String type);
+    List<Long> getByType(String type);
     Double getTotalAmount(Long id);
 }

--- a/src/main/java/com/mendel/challenge/service/TransactionService.java
+++ b/src/main/java/com/mendel/challenge/service/TransactionService.java
@@ -1,0 +1,9 @@
+package com.mendel.challenge.service;
+
+import com.mendel.challenge.entity.Transaction;
+
+public interface TransactionService {
+    Transaction get(Long id);
+    Transaction getByType(String type);
+    Double getTotalAmount(Long id);
+}

--- a/src/main/java/com/mendel/challenge/service/impl/TransactionServiceImpl.java
+++ b/src/main/java/com/mendel/challenge/service/impl/TransactionServiceImpl.java
@@ -3,7 +3,6 @@ package com.mendel.challenge.service.impl;
 import com.mendel.challenge.entity.Transaction;
 import com.mendel.challenge.repository.TransactionRepository;
 import com.mendel.challenge.service.TransactionService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -29,6 +28,12 @@ public class TransactionServiceImpl implements TransactionService {
     @Override
     public Double getTotalAmount(Long id) {
         Double totalAmountResult = 0.0;
+
+        totalAmountResult = transactionRepository.getByRelationship(id)
+                .stream()
+                .mapToDouble(Transaction::getAmount)
+                .sum();
+
         return totalAmountResult;
     }
 }

--- a/src/main/java/com/mendel/challenge/service/impl/TransactionServiceImpl.java
+++ b/src/main/java/com/mendel/challenge/service/impl/TransactionServiceImpl.java
@@ -4,11 +4,17 @@ import com.mendel.challenge.entity.Transaction;
 import com.mendel.challenge.repository.TransactionRepository;
 import com.mendel.challenge.service.TransactionService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
+@Service
 public class TransactionServiceImpl implements TransactionService {
 
-    @Autowired
+
     private TransactionRepository transactionRepository;
+
+    public TransactionServiceImpl(TransactionRepository transactionRepository) {
+        this.transactionRepository = transactionRepository;
+    }
 
     @Override
     public Transaction get(Long id) {
@@ -22,6 +28,7 @@ public class TransactionServiceImpl implements TransactionService {
 
     @Override
     public Double getTotalAmount(Long id) {
-        return null;
+        Double totalAmountResult = 0.0;
+        return totalAmountResult;
     }
 }

--- a/src/main/java/com/mendel/challenge/service/impl/TransactionServiceImpl.java
+++ b/src/main/java/com/mendel/challenge/service/impl/TransactionServiceImpl.java
@@ -5,6 +5,9 @@ import com.mendel.challenge.repository.TransactionRepository;
 import com.mendel.challenge.service.TransactionService;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 public class TransactionServiceImpl implements TransactionService {
 
@@ -17,12 +20,16 @@ public class TransactionServiceImpl implements TransactionService {
 
     @Override
     public Transaction get(Long id) {
-        return null;
+        return transactionRepository.get(id);
     }
 
     @Override
-    public Transaction getByType(String type) {
-        return null;
+    public List<Long> getByType(String type) {
+
+        return transactionRepository.getByType(type)
+                .stream()
+                .map(Transaction::getId)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/mendel/challenge/service/impl/TransactionServiceImpl.java
+++ b/src/main/java/com/mendel/challenge/service/impl/TransactionServiceImpl.java
@@ -1,0 +1,27 @@
+package com.mendel.challenge.service.impl;
+
+import com.mendel.challenge.entity.Transaction;
+import com.mendel.challenge.repository.TransactionRepository;
+import com.mendel.challenge.service.TransactionService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class TransactionServiceImpl implements TransactionService {
+
+    @Autowired
+    private TransactionRepository transactionRepository;
+
+    @Override
+    public Transaction get(Long id) {
+        return null;
+    }
+
+    @Override
+    public Transaction getByType(String type) {
+        return null;
+    }
+
+    @Override
+    public Double getTotalAmount(Long id) {
+        return null;
+    }
+}

--- a/src/test/java/com/mendel/challenge/unit/impl/repository/TransactionRepositoryImplTest.java
+++ b/src/test/java/com/mendel/challenge/unit/impl/repository/TransactionRepositoryImplTest.java
@@ -3,6 +3,7 @@ package com.mendel.challenge.unit.impl.repository;
 import com.mendel.challenge.common.TransactionTypes;
 import com.mendel.challenge.entity.Transaction;
 import com.mendel.challenge.repository.impl.TransactionRepositoryImpl;
+import com.mendel.challenge.util.TransactionsMock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
@@ -14,42 +15,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TransactionRepositoryImplTest {
 
-
     private TransactionRepositoryImpl transactionRepository;
-
-
+    private static TransactionsMock transactionsMock = new TransactionsMock();
     private void prepareMocks() {
         this.transactionRepository = new TransactionRepositoryImpl();
-
-        transactionRepository.save(
-                Transaction.builder()
-                        .id(1L)
-                        .amount(1.0)
-                        .type(TransactionTypes.CARS.getName())
-                        .build()
-        );
-        transactionRepository.save(
-                Transaction.builder()
-                        .id(2L)
-                        .amount(2.0)
-                        .type(TransactionTypes.GROCERIES.getName())
-                        .parentId(1L)
-                        .build()
-        );
-        transactionRepository.save(
-                Transaction.builder()
-                        .id(3L)
-                        .amount(3.0)
-                        .type(TransactionTypes.CARS.getName())
-                        .build()
-        );
-        transactionRepository.save(
-                Transaction.builder()
-                        .id(4L)
-                        .amount(4.0)
-                        .type(TransactionTypes.SHOPPING.getName())
-                        .build()
-        );
+        transactionsMock.getCommonExample().forEach(transaction -> transactionRepository.save(transaction));
     }
 
     @BeforeEach

--- a/src/test/java/com/mendel/challenge/unit/impl/service/TransactionServiceTest.java
+++ b/src/test/java/com/mendel/challenge/unit/impl/service/TransactionServiceTest.java
@@ -1,5 +1,6 @@
 package com.mendel.challenge.unit.impl.service;
 
+import com.mendel.challenge.common.TransactionTypes;
 import com.mendel.challenge.repository.TransactionRepository;
 import com.mendel.challenge.repository.impl.TransactionRepositoryImpl;
 import com.mendel.challenge.service.TransactionService;
@@ -28,21 +29,62 @@ class TransactionServiceTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-
     }
 
-    void getTransaction() {
+    @Test
+    void getTransaction_OK() {
+        when(transactionRepository.get(any())).thenReturn(transactionsMock.getOnlyOne());
+
+        var result = transactionService.get(transactionsMock.getOnlyOne().getId());
+
+        assertEquals(result, transactionsMock.getOnlyOne());
     }
 
-    void getTransactionByType() {
+    @Test
+    void getTransaction_NotFound() {
+        when(transactionRepository.get(any())).thenReturn(null);
+
+        var result = transactionService.get(transactionsMock.getOnlyOne().getId());
+
+        assertEquals(result, null);
+    }
+
+    @Test
+    void getTransactionByType_NotFound() {
+
+        when(transactionRepository.getByType(any())).thenReturn(Arrays.asList());
+
+        var result = transactionService.getByType(null);
+
+        assertEquals(result.size(), 0);
+    }
+
+    @Test
+    void getTransactionByType_OK() {
+
+        when(transactionRepository.getByType(any())).thenReturn(transactionsMock.getOnly2CarsTransactions());
+
+        var result = transactionService.getByType(TransactionTypes.CARS.getName());
+
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void getTransactionByType_nullID() {
+
+        when(transactionRepository.getByType(any())).thenReturn(Arrays.asList());
+
+        var result = transactionService.getByType(null);
+
+        assertEquals(0, result.size());
     }
 
     @Test
     void getTotalAmountTransaction_notFound() {
 
-        when(transactionRepository.getByType(anyString())).thenReturn(Arrays.asList());
+        when(transactionRepository.getByRelationship(any())).thenReturn(Arrays.asList());
 
-        Double totalAmount = transactionService.getTotalAmount(33L);
+        var totalAmount = transactionService.getTotalAmount(33L);
 
         assertEquals(totalAmount, 0.0);
     }
@@ -52,8 +94,28 @@ class TransactionServiceTest {
 
         when(transactionRepository.getByRelationship(any())).thenReturn(transactionsMock.getOnlyParents());
 
-        Double totalAmount = transactionService.getTotalAmount(1L);
+        var totalAmount = transactionService.getTotalAmount(1L);
 
         assertEquals(3.0, totalAmount);
+    }
+
+    @Test
+    void getTotalAmountTransaction_OnlyOneOK() {
+
+        when(transactionRepository.getByRelationship(any())).thenReturn(Arrays.asList(transactionsMock.getOnlyOne()));
+
+        var totalAmount = transactionService.getTotalAmount(1L);
+
+        assertEquals(transactionsMock.getOnlyOne().getAmount(), totalAmount);
+    }
+
+    @Test
+    void getTotalAmountTransaction_nullFromRepository() {
+
+        when(transactionRepository.getByType(anyString())).thenReturn(null);
+
+        var totalAmount = transactionService.getTotalAmount(33L);
+
+        assertEquals(totalAmount, 0.0);
     }
 }

--- a/src/test/java/com/mendel/challenge/unit/impl/service/TransactionServiceTest.java
+++ b/src/test/java/com/mendel/challenge/unit/impl/service/TransactionServiceTest.java
@@ -1,0 +1,28 @@
+package com.mendel.challenge.unit.impl.service;
+
+import com.mendel.challenge.repository.TransactionRepository;
+import com.mendel.challenge.service.TransactionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+
+class TransactionServiceTest {
+
+    @Mock
+    private TransactionRepository transactionRepository;
+
+    @InjectMocks
+    private TransactionService transactionService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+    }
+
+    void getTransaction(){}
+    void getTransactionByType(){}
+    void getTotalAmountTransaction(){}
+}

--- a/src/test/java/com/mendel/challenge/unit/impl/service/TransactionServiceTest.java
+++ b/src/test/java/com/mendel/challenge/unit/impl/service/TransactionServiceTest.java
@@ -1,24 +1,28 @@
 package com.mendel.challenge.unit.impl.service;
 
 import com.mendel.challenge.repository.TransactionRepository;
+import com.mendel.challenge.repository.impl.TransactionRepositoryImpl;
 import com.mendel.challenge.service.TransactionService;
 import com.mendel.challenge.service.impl.TransactionServiceImpl;
+import com.mendel.challenge.util.TransactionsMock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
 class TransactionServiceTest {
 
-    @Mock
-    private TransactionRepository transactionRepository;
+
+    private static TransactionsMock transactionsMock = new TransactionsMock();
+    private TransactionRepository transactionRepository = mock(TransactionRepositoryImpl.class);
     private TransactionService transactionService = new TransactionServiceImpl(transactionRepository);
 
     @BeforeEach
@@ -41,5 +45,15 @@ class TransactionServiceTest {
         Double totalAmount = transactionService.getTotalAmount(33L);
 
         assertEquals(totalAmount, 0.0);
+    }
+
+    @Test
+    void getTotalAmountTransaction_OK() {
+
+        when(transactionRepository.getByRelationship(any())).thenReturn(transactionsMock.getOnlyParents());
+
+        Double totalAmount = transactionService.getTotalAmount(1L);
+
+        assertEquals(3.0, totalAmount);
     }
 }

--- a/src/test/java/com/mendel/challenge/unit/impl/service/TransactionServiceTest.java
+++ b/src/test/java/com/mendel/challenge/unit/impl/service/TransactionServiceTest.java
@@ -2,19 +2,24 @@ package com.mendel.challenge.unit.impl.service;
 
 import com.mendel.challenge.repository.TransactionRepository;
 import com.mendel.challenge.service.TransactionService;
+import com.mendel.challenge.service.impl.TransactionServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 
 class TransactionServiceTest {
 
     @Mock
     private TransactionRepository transactionRepository;
-
-    @InjectMocks
-    private TransactionService transactionService;
+    private TransactionService transactionService = new TransactionServiceImpl(transactionRepository);
 
     @BeforeEach
     void setUp() {
@@ -22,7 +27,19 @@ class TransactionServiceTest {
 
     }
 
-    void getTransaction(){}
-    void getTransactionByType(){}
-    void getTotalAmountTransaction(){}
+    void getTransaction() {
+    }
+
+    void getTransactionByType() {
+    }
+
+    @Test
+    void getTotalAmountTransaction_notFound() {
+
+        when(transactionRepository.getByType(anyString())).thenReturn(Arrays.asList());
+
+        Double totalAmount = transactionService.getTotalAmount(33L);
+
+        assertEquals(totalAmount, 0.0);
+    }
 }

--- a/src/test/java/com/mendel/challenge/util/TransactionsMock.java
+++ b/src/test/java/com/mendel/challenge/util/TransactionsMock.java
@@ -7,28 +7,29 @@ import java.util.Arrays;
 import java.util.List;
 
 public final class TransactionsMock {
+    private Transaction ONLY_ONE = Transaction.builder()
+            .id(1L)
+            .amount(1.0)
+            .type(TransactionTypes.CARS.getName())
+            .build();
     private List<Transaction> COMMON_EXAMPLE = Arrays.asList(
+            ONLY_ONE,
             Transaction.builder()
-                .id(1L)
-                .amount(1.0)
-                .type(TransactionTypes.CARS.getName())
-                .build(),
+                    .id(2L)
+                    .amount(2.0)
+                    .type(TransactionTypes.GROCERIES.getName())
+                    .parentId(1L)
+                    .build(),
             Transaction.builder()
-                .id(2L)
-                .amount(2.0)
-                .type(TransactionTypes.GROCERIES.getName())
-                .parentId(1L)
-                .build(),
+                    .id(3L)
+                    .amount(3.0)
+                    .type(TransactionTypes.CARS.getName())
+                    .build(),
             Transaction.builder()
-                .id(3L)
-                .amount(3.0)
-                .type(TransactionTypes.CARS.getName())
-                .build(),
-            Transaction.builder()
-                .id(4L)
-                .amount(4.0)
-                .type(TransactionTypes.SHOPPING.getName())
-                .build()
+                    .id(4L)
+                    .amount(4.0)
+                    .type(TransactionTypes.SHOPPING.getName())
+                    .build()
     );
 
     private List<Transaction> ONLY_PARENT = Arrays.asList(
@@ -45,13 +46,35 @@ public final class TransactionsMock {
                     .build()
     );
 
+    private List<Transaction> ONLY_2_CARS = Arrays.asList(
+            Transaction.builder()
+                    .id(1L)
+                    .amount(1.0)
+                    .type(TransactionTypes.CARS.getName())
+                    .build(),
+            Transaction.builder()
+                    .id(2L)
+                    .amount(2.0)
+                    .type(TransactionTypes.CARS.getName())
+                    .parentId(1L)
+                    .build()
+    );
 
-    public List<Transaction> getCommonExample(){
+
+    public List<Transaction> getCommonExample() {
         return COMMON_EXAMPLE;
     }
 
-    public List<Transaction> getOnlyParents(){
+    public List<Transaction> getOnlyParents() {
         return ONLY_PARENT;
+    }
+
+    public Transaction getOnlyOne() {
+        return ONLY_ONE;
+    }
+
+    public List<Transaction> getOnly2CarsTransactions() {
+        return ONLY_2_CARS;
     }
 
 }

--- a/src/test/java/com/mendel/challenge/util/TransactionsMock.java
+++ b/src/test/java/com/mendel/challenge/util/TransactionsMock.java
@@ -1,0 +1,39 @@
+package com.mendel.challenge.util;
+
+import com.mendel.challenge.common.TransactionTypes;
+import com.mendel.challenge.entity.Transaction;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class TransactionsMock {
+    private List<Transaction> COMMON_EXAMPLE = Arrays.asList(
+            Transaction.builder()
+                .id(1L)
+                .amount(1.0)
+                .type(TransactionTypes.CARS.getName())
+                .build(),
+            Transaction.builder()
+                .id(2L)
+                .amount(2.0)
+                .type(TransactionTypes.GROCERIES.getName())
+                .parentId(1L)
+                .build(),
+            Transaction.builder()
+                .id(3L)
+                .amount(3.0)
+                .type(TransactionTypes.CARS.getName())
+                .build(),
+            Transaction.builder()
+                .id(4L)
+                .amount(4.0)
+                .type(TransactionTypes.SHOPPING.getName())
+                .build()
+    );
+
+
+    public List<Transaction> getCommonExample(){
+        return COMMON_EXAMPLE;
+    }
+
+}

--- a/src/test/java/com/mendel/challenge/util/TransactionsMock.java
+++ b/src/test/java/com/mendel/challenge/util/TransactionsMock.java
@@ -31,9 +31,27 @@ public final class TransactionsMock {
                 .build()
     );
 
+    private List<Transaction> ONLY_PARENT = Arrays.asList(
+            Transaction.builder()
+                    .id(1L)
+                    .amount(1.0)
+                    .type(TransactionTypes.CARS.getName())
+                    .build(),
+            Transaction.builder()
+                    .id(2L)
+                    .amount(2.0)
+                    .type(TransactionTypes.GROCERIES.getName())
+                    .parentId(1L)
+                    .build()
+    );
+
 
     public List<Transaction> getCommonExample(){
         return COMMON_EXAMPLE;
+    }
+
+    public List<Transaction> getOnlyParents(){
+        return ONLY_PARENT;
     }
 
 }


### PR DESCRIPTION
Se agrega la capa de servicio

- Logica de suma de los transacciones que estan relacionados por el parentID
- Obtención de una transacción
- Obtención del listado de _transactions_id_ por tipo